### PR TITLE
setup.py - don't depend on pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name='TravisPy',
     version='0.3.5',
     packages=['travispy', 'travispy.entities'],
-    install_requires=[x.strip() for x in open('requirements.txt')],
+    install_requires=['requests'],
 
     # metadata for upload to PyPI
     author='Fabio Menegazzo',


### PR DESCRIPTION
Installing currently causes `pytest` and `pytest-rerunfailures` to be unnecessarily installed which is a pain for environments or people that don't use `pytest` for tests. Fix that.