### PR TITLE
Add status_code to TravisError

### DIFF
--- a/travispy/_tests/test_errors.py
+++ b/travispy/_tests/test_errors.py
@@ -1,0 +1,8 @@
+from travispy.errors import TravisError
+
+
+class Tests:
+
+    def test_status_code(self):
+        error = TravisError({'status_code': 404, 'error': 'Not Found'})
+        assert error.status_code == 404

--- a/travispy/errors.py
+++ b/travispy/errors.py
@@ -8,11 +8,10 @@ class TravisError(Exception):
 
     def __init__(self, contents):
         self._contents = contents
+        self.status_code = contents['status_code']
         Exception.__init__(self, self.message())
 
     def message(self):
-        status_code = self._contents.pop('status_code')
-
         # Trying to get error message from "error/message" key.
         message = self._contents.get('error')
         if isinstance(message, dict):
@@ -22,4 +21,4 @@ class TravisError(Exception):
         if message is None:
             message = self._contents.get('file')
 
-        return '[%d] %s' % (status_code, message or 'Unknown error')
+        return '[%d] %s' % (self.status_code, message or 'Unknown error')


### PR DESCRIPTION
I wanted to access it to filter 404's but the constructor was removing it from _contents so it wasn't accessible. This makes it a permanent attribute of the exception.