### PR TITLE
Test with tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,9 @@
 sudo: false
 language: python
-python:
-- 2.7
-- 3.4
-- 3.5
-- pypy
+python: 3.5
 install:
-- pip install pytest
-- pip install pytest-rerunfailures
-- pip install requests
-- pip install coveralls
+- pip install coveralls tox
 script:
-- coverage run --source=travispy setup.py test -a -rxs
+- tox
 after_success:
 - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests
+coverage
 pytest
 pytest-rerunfailures
+requests

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py{27,34,35,py}
+
+[testenv]
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+deps = -rrequirements.txt
+commands = coverage run --source=travispy setup.py test -a -rxs


### PR DESCRIPTION
[tox](https://tox.readthedocs.io) makes testing with multiple python versions locally easy. It also allows the installation steps to be automated so users need just run 'tox' to run the tests.
