### PR TITLE
Travis CI: Drop EOLed Python 3.4 and add 3.7 and flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 - 3.7
 - pypy
 install:
-- pip install --upgrade pip setuptools
-- pip install coveralls flake8 pytest pytest-rerunfailures requests
+- pip install --upgrade pip
+- pip install coveralls flake8 pytest pytest-rerunfailures requests tox
 script:
 - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
 - coverage run --source=travispy setup.py test -a -rxs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
-sudo: false
+dist: xenial  # required for Python >= 3.7
 language: python
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
+- 3.7
 - pypy
 install:
-- pip install pytest
-- pip install pytest-rerunfailures
-- pip install requests
-- pip install coveralls
+- pip install --upgrade pip
+- pip install coveralls flake8 pytest pytest-rerunfailures requests
 script:
+- flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
 - coverage run --source=travispy setup.py test -a -rxs
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 - 3.7
 - pypy
 install:
-- pip install --upgrade pip
+- pip install --upgrade pip setuptools
 - pip install coveralls flake8 pytest pytest-rerunfailures requests
 script:
 - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 - pypy
 install:
 - pip install --upgrade pip
-- pip install coveralls flake8 pytest pytest-rerunfailures requests tox
+- pip install coveralls flake8 pytest requests tox  # pytest-rerunfailures
 script:
 - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
 - coverage run --source=travispy setup.py test -a -rxs

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. |travispy| replace:: **TravisPy**
+.. |travispy| replace:: **TravisPy** 
 .. |travisci| replace:: *Travis CI*
 .. |github| replace:: *GitHub*
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name='TravisPy',
     version='0.3.5',
     packages=['travispy', 'travispy.entities'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*', !=3.4.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=['requests'],
 
     # metadata for upload to PyPI

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name='TravisPy',
     version='0.3.5',
     packages=['travispy', 'travispy.entities'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*', !=3.4.*',
     install_requires=['requests'],
 
     # metadata for upload to PyPI
@@ -48,9 +48,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 c[tox]
-envlist = py{27,34,35,36,py}
+envlist = py{27,35,36,37,py}
 
 [testenv]
 passenv = TRAVISPY_TEST_SETTINGS

--- a/travispy/_tests/test_not_authenticated.py
+++ b/travispy/_tests/test_not_authenticated.py
@@ -2,7 +2,11 @@ from travispy import TravisPy
 from travispy.entities import Job, Log, Repo
 from travispy.errors import TravisError
 import pytest
-import sys
+
+try:
+    unicode_type = unicode  # Python 2
+except NameError:
+    unicode_type = str      # Python 3
 
 
 @pytest.fixture(scope='module')
@@ -203,7 +207,6 @@ def test_archived_log(travis):
 
     # Dynamically fetch the log
     assert log.body
-    unicode_type = unicode if sys.version_info[0] == 2 else str
     assert isinstance(log.body, unicode_type)
 
     job = log.job


### PR DESCRIPTION
Python 3.4 has reached its end of life. https://devguide.python.org/devcycle/#end-of-life-branches

Also, follow Python porting best practice [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"